### PR TITLE
fixed the traffic violations back navigation

### DIFF
--- a/app/src/main/java/com/course_project_autotrace/TrafficViolations/TrafficViolations.java
+++ b/app/src/main/java/com/course_project_autotrace/TrafficViolations/TrafficViolations.java
@@ -75,7 +75,7 @@ public class TrafficViolations extends AppCompatActivity implements TrafficViola
         LocationTextView = findViewById(R.id.descriptionTextView);
 
         // Navigation Button Handlers
-        findViewById(R.id.BackBtn).setOnClickListener(v -> navigateTo(TrafficViolations.class));
+        findViewById(R.id.BackBtn).setOnClickListener(v -> navigateTo(HomeScreen.class));
         findViewById(R.id.violationBtn).setOnClickListener(v -> navigateTo(TrafficViolations.class));
         findViewById(R.id.profileBTN).setOnClickListener(v -> navigateTo(ProfileView.class));
         findViewById(R.id.CarInfoBtn).setOnClickListener(v -> navigateTo(CarInfo.class));


### PR DESCRIPTION
# Description

The TrafficViolations.class back button was navigating back to the same page.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas